### PR TITLE
chore: update agent identity to Pi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A dynamic version source plugin for uv workspaces."
 readme = "README.md"
 authors = [
     { name = "Indivar Mishra", email = "indimishra@gmail.com" },
-    { name = "Antigravity", email = "antigravity@google.com" }
+    { name = "Pi", email = "pi@google.com" }
 ]
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
Closes #3

This PR updates the agent identity from Antigravity to Pi.

Changes:
- Updated `pyproject.toml` authors list.
- Configured local Git user for future commits.