### PR TITLE
chore: align author email with Git history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A dynamic version source plugin for uv workspaces."
 readme = "README.md"
 authors = [
     { name = "Indivar Mishra", email = "indimishra@gmail.com" },
-    { name = "Pi", email = "pi@google.com" }
+    { name = "Pi", email = "pi@pi.dev" }
 ]
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
Closes #5

This PR aligns the author email in `pyproject.toml` with the newly rewritten Git history (`pi@pi.dev`).