### PR TITLE
chore: update project memory with new identity

### DIFF
--- a/.memory/branches/main/commits.md
+++ b/.memory/branches/main/commits.md
@@ -248,3 +248,11 @@ The project is a `hatch` extension for `uv` workspaces using `hatchling` and `du
 
 - Added Antigravity as a co-author in `pyproject.toml` to acknowledge the agent's contributions to the codebase, documentation, and architectural refinements.
 - Formalized the collaborative development state of the project within the package metadata.
+
+---
+
+## Commit ec1a974d | 2026-03-16T23:42:12.301Z
+
+### Merge from ci-cd-workflow
+
+Integrated CI/CD workflow with GitHub Actions. Standardized linting with Ruff and testing with Pytest. Configured automated PyPI publishing on tag creation. All changes merged into main.

--- a/.memory/state.yaml
+++ b/.memory/state.yaml
@@ -1,10 +1,10 @@
-active_branch: "ci-cd-workflow"
+active_branch: main
 initialized: "2026-03-16T22:17:27Z"
 last_commit:
   branch: main
-  hash: e78feeb2
-  timestamp: "2026-03-16T23:24:25.323Z"
-  summary: "chore(repo): add Antigravity as co-author in pyproject.toml"
+  hash: ec1a974d
+  timestamp: "2026-03-16T23:42:12.301Z"
+  summary: "Merge from ci-cd-workflow"
 sessions:
   - file: "/home/indivar/.pi/agent/sessions/--home-indivar-github-uv-workspace-dynamic-versioning--/2026-03-16T22-17-11-584Z_cf26c542-00f8-4841-9174-7ef2aebb0c3f.jsonl"
     branch: main
@@ -13,5 +13,5 @@ sessions:
     branch: main
     started: "2026-03-16T23:31:56.451Z"
   - file: "/home/indivar/.pi/agent/sessions/--home-indivar-github-uv-workspace-dynamic-versioning--/2026-03-16T23-34-16-409Z_cbcba5d0-f860-4d6f-ac72-f2a995caa4e3.jsonl"
-    branch: "ci-cd-workflow"
+    branch: main
     started: "2026-03-16T23:34:16.456Z"


### PR DESCRIPTION
Closes #7

This PR synchronizes the `.memory/` directory with the latest repository changes.